### PR TITLE
Merge First - This issue is causing Travis to fail on all merges

### DIFF
--- a/tests/TDD/Chapter1/Chapter1Test.php
+++ b/tests/TDD/Chapter1/Chapter1Test.php
@@ -2,7 +2,7 @@
 
 namespace TDD\Chapter1;
 
-class Chapter1Test extends TestCase 
+class Chapter1Test extends \PHPUnit_Framework_TestCase 
 {
 	/**
 	 * Tests that Dollar's public variable, $amount, is the same as the given amount


### PR DESCRIPTION
In one of the merges I left my newer version of TestCase as the parent class in the test. The original is using \PHPUnit_Framework_TestCase .

Because of this when I pull from upstream, then push to a branch, then finally a pull request this erroring TestCase class does not exist and is causing a failure to branches that have been rebased.

Correcting for older phpunit parent class

Thank you for your patience @guhelski !